### PR TITLE
Fix header name not showing in zabbix-6.0.2-gauge.patch

### DIFF
--- a/zabbix-5.4.11-gauge.patch
+++ b/zabbix-5.4.11-gauge.patch
@@ -337,7 +337,7 @@ index 0000000..d38191a
 +}
 +
 +$output = [
-+	'header' => $data['name'], 
++	'name' => $data['name'], 
 +	'body' => $gauge_item->toString()
 +];
 +

--- a/zabbix-6.0.1-gauge.patch
+++ b/zabbix-6.0.1-gauge.patch
@@ -337,7 +337,7 @@ index 0000000..d38191a
 +}
 +
 +$output = [
-+	'header' => $data['name'], 
++	'name' => $data['name'], 
 +	'body' => $gauge_item->toString()
 +];
 +

--- a/zabbix-6.0.2-gauge.patch
+++ b/zabbix-6.0.2-gauge.patch
@@ -359,7 +359,7 @@ index 0000000..7b81d29
 +}
 +
 +$output = [
-+	'header' => $data['name'], 
++	'name' => $data['name'], 
 +	'body' => $gauge_item->toString()
 +];
 +


### PR DESCRIPTION
The header name was not showing on the dashboard. This is because it was send under the variable name 'header' instead of the expected variable name 'name'.

Issue number #2